### PR TITLE
[feat] event 조회, 검색 api 

### DIFF
--- a/src/api/axios/Home/homeAxios.ts
+++ b/src/api/axios/Home/homeAxios.ts
@@ -3,7 +3,7 @@ import { isAxiosError } from 'axios';
 import instance from '@/api/axios/instance';
 
 const AUTH_URL = {
-  getEventsUrl: '/api/events',
+  GET_EVENT_URL: '/api/events',
 };
 
 const MESSAGES = {
@@ -18,9 +18,9 @@ interface EventData {
   period: string;
 }
 
-export const axiosEventsData = async (searchContent = ''): Promise<EventData[]> => {
+export const getEventsData = async (searchContent = ''): Promise<EventData[]> => {
   try {
-    const response = await instance.get(AUTH_URL.getEventsUrl, {
+    const response = await instance.get(AUTH_URL.GET_EVENT_URL, {
       params: {
         content: searchContent,
       },

--- a/src/api/axios/Home/homeAxios.ts
+++ b/src/api/axios/Home/homeAxios.ts
@@ -18,9 +18,13 @@ interface EventData {
   period: string;
 }
 
-export const axiosEventsData = async (): Promise<EventData[]> => {
+export const axiosEventsData = async (searchContent = ''): Promise<EventData[]> => {
   try {
-    const response = await instance.get(AUTH_URL.getEventsUrl);
+    const response = await instance.get(AUTH_URL.getEventsUrl, {
+      params: {
+        content: searchContent,
+      },
+    });
     return response.data.data.events;
   } catch (error) {
     if (isAxiosError(error)) throw error;

--- a/src/api/axios/Home/homeAxios.ts
+++ b/src/api/axios/Home/homeAxios.ts
@@ -1,0 +1,29 @@
+import { isAxiosError } from 'axios';
+
+import instance from '@/api/axios/instance';
+
+const AUTH_URL = {
+  getEventsUrl: '/api/events',
+};
+
+const MESSAGES = {
+  UNKNOWN_ERROR: '알수없는 오류가 발생했습니다. 다시 시도해주세요.',
+};
+
+interface EventData {
+  id: number;
+  image: string;
+  name: string;
+  description: string;
+  period: string;
+}
+
+export const axiosEventsData = async (): Promise<EventData[]> => {
+  try {
+    const response = await instance.get(AUTH_URL.getEventsUrl);
+    return response.data.data.events;
+  } catch (error) {
+    if (isAxiosError(error)) throw error;
+    else throw new Error(MESSAGES.UNKNOWN_ERROR);
+  }
+};

--- a/src/components/event/EventBox.tsx
+++ b/src/components/event/EventBox.tsx
@@ -1,17 +1,42 @@
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import Event from '@/components/event/Event';
 
-import { EVENT_DATA } from '@/constants/eventData';
+import { axiosEventsData } from '@/api/axios/Home/homeAxios';
 
 interface EventBoxProps {
   isShowPeriod: boolean;
 }
 
+interface EventData {
+  id: number;
+  image: string;
+  name: string;
+  description: string;
+  period: string;
+}
+
 function EventBox({ isShowPeriod }: EventBoxProps) {
+  const [eventData, setEventData] = useState<EventData[]>([]);
+
+  useEffect(() => {
+    const fetchEventData = async () => {
+      try {
+        const eventData = await axiosEventsData();
+        setEventData(eventData);
+        console.log(eventData);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    fetchEventData();
+  }, []);
+
   return (
     <EventBoxLayout>
-      {EVENT_DATA.map(({ id, image, name, description, period }) => (
+      {eventData.map(({ id, image, name, description, period }) => (
         <Event
           key={id}
           image={image}

--- a/src/components/event/EventBox.tsx
+++ b/src/components/event/EventBox.tsx
@@ -7,6 +7,7 @@ import { axiosEventsData } from '@/api/axios/Home/homeAxios';
 
 interface EventBoxProps {
   isShowPeriod: boolean;
+  searchWord?: string;
 }
 
 interface EventData {
@@ -17,13 +18,13 @@ interface EventData {
   period: string;
 }
 
-function EventBox({ isShowPeriod }: EventBoxProps) {
+function EventBox({ isShowPeriod, searchWord }: EventBoxProps) {
   const [eventData, setEventData] = useState<EventData[]>([]);
 
   useEffect(() => {
     const fetchEventData = async () => {
       try {
-        const eventData = await axiosEventsData();
+        const eventData = await axiosEventsData(searchWord);
         setEventData(eventData);
       } catch (error) {
         console.error(error);
@@ -31,7 +32,7 @@ function EventBox({ isShowPeriod }: EventBoxProps) {
     };
 
     fetchEventData();
-  }, []);
+  }, [searchWord]);
 
   return (
     <EventBoxLayout>

--- a/src/components/event/EventBox.tsx
+++ b/src/components/event/EventBox.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import Event from '@/components/event/Event';
 
-import { axiosEventsData } from '@/api/axios/Home/homeAxios';
+import { getEventsData } from '@/api/axios/Home/homeAxios';
 
 interface EventBoxProps {
   isShowPeriod: boolean;
@@ -24,7 +24,7 @@ function EventBox({ isShowPeriod, searchWord }: EventBoxProps) {
   useEffect(() => {
     const fetchEventData = async () => {
       try {
-        const eventData = await axiosEventsData(searchWord);
+        const eventData = await getEventsData(searchWord);
         setEventData(eventData);
       } catch (error) {
         console.error(error);

--- a/src/components/event/EventBox.tsx
+++ b/src/components/event/EventBox.tsx
@@ -25,7 +25,6 @@ function EventBox({ isShowPeriod }: EventBoxProps) {
       try {
         const eventData = await axiosEventsData();
         setEventData(eventData);
-        console.log(eventData);
       } catch (error) {
         console.error(error);
       }

--- a/src/pages/Benefit/_components/BenefitEvent.tsx
+++ b/src/pages/Benefit/_components/BenefitEvent.tsx
@@ -19,6 +19,7 @@ const CurrentEvenSection = styled.div`
 `;
 
 const CurrentEventTitle = styled.h2`
-  font-size: ${({ theme }) => theme.FONT_SIZE.HEAD_03};
   margin-bottom: 2rem;
+
+  font-size: ${({ theme }) => theme.FONT_SIZE.HEAD_03};
 `;

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import styled from 'styled-components';
 
 import Carousel from '@/pages/Home/_components/Carousel';
@@ -10,9 +11,14 @@ import EventBox from '@/components/event/EventBox';
 import IconVector from '@/assets/svg/vector2.svg?react';
 
 function Home() {
+  const [searchWord, setSearchWord] = useState<string>('');
+  const handleSearchWord = (keyword: string) => {
+    setSearchWord(keyword);
+  };
+
   return (
     <HomePageLayout>
-      <Input />
+      <Input searchWord={searchWord} handleSearchWord={handleSearchWord} />
       <Carousel />
       <HomeCardSection>
         <HomeCardArea
@@ -30,7 +36,7 @@ function Home() {
         />
       </HomeCardSection>
       <EventSection>
-        <EventBox isShowPeriod={false} />
+        <EventBox isShowPeriod={false} searchWord={searchWord} />
       </EventSection>
     </HomePageLayout>
   );

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import styled from 'styled-components';
 
 import Carousel from '@/pages/Home/_components/Carousel';
@@ -14,7 +14,11 @@ function Home() {
   const [searchWord, setSearchWord] = useState('');
   const handleSearchWord = (keyword: string) => {
     setSearchWord(keyword);
+    if (eventSectionRef.current) {
+      eventSectionRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
   };
+  const eventSectionRef = useRef<HTMLDivElement>(null);
 
   return (
     <HomePageLayout>
@@ -35,7 +39,7 @@ function Home() {
           hashtags={['프리미엄', '쓸 때마다 할인', '어디서나 포인트적립', '3F 시스템 혜택']}
         />
       </HomeCardSection>
-      <EventSection>
+      <EventSection ref={eventSectionRef}>
         <EventBox isShowPeriod={false} searchWord={searchWord} />
       </EventSection>
     </HomePageLayout>

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -11,14 +11,14 @@ import EventBox from '@/components/event/EventBox';
 import IconVector from '@/assets/svg/vector2.svg?react';
 
 function Home() {
-  const [searchWord, setSearchWord] = useState<string>('');
+  const [searchWord, setSearchWord] = useState('');
   const handleSearchWord = (keyword: string) => {
     setSearchWord(keyword);
   };
 
   return (
     <HomePageLayout>
-      <Input searchWord={searchWord} handleSearchWord={handleSearchWord} />
+      <Input handleSearchWord={handleSearchWord} />
       <Carousel />
       <HomeCardSection>
         <HomeCardArea

--- a/src/pages/Home/_components/Input.tsx
+++ b/src/pages/Home/_components/Input.tsx
@@ -19,13 +19,19 @@ function Input({ searchWord, handleSearchWord }: InputProps) {
     setInputValue(event.target.value);
   };
 
+  const handleEnterKey = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      handleSearchWord(inputValue);
+    }
+  };
   return (
     <InputLayout>
       <InputBox
         placeholder='카드, 메뉴, 혜택을 검색해 보세요'
         value={inputValue}
         onChange={handleChange}
-      ></InputBox>
+        onKeyDown={handleEnterKey}
+      />
       <IconSearch onClick={handleKeyPress} />
     </InputLayout>
   );

--- a/src/pages/Home/_components/Input.tsx
+++ b/src/pages/Home/_components/Input.tsx
@@ -4,12 +4,11 @@ import styled from 'styled-components';
 import IconSearch from '@/assets/svg/ic_search.svg?react';
 
 interface InputProps {
-  searchWord: string;
   handleSearchWord: (keyword: string) => void;
 }
 
-function Input({ searchWord, handleSearchWord }: InputProps) {
-  const [inputValue, setInputValue] = useState(searchWord);
+function Input({ handleSearchWord }: InputProps) {
+  const [inputValue, setInputValue] = useState('');
 
   const handleKeyPress = () => {
     handleSearchWord(inputValue);

--- a/src/pages/Home/_components/Input.tsx
+++ b/src/pages/Home/_components/Input.tsx
@@ -10,11 +10,11 @@ interface InputProps {
 function Input({ handleSearchWord }: InputProps) {
   const [inputValue, setInputValue] = useState('');
 
-  const handleKeyPress = () => {
+  const handleClickSearch = () => {
     handleSearchWord(inputValue);
   };
 
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChangeInput = (event: React.ChangeEvent<HTMLInputElement>) => {
     setInputValue(event.target.value);
   };
 
@@ -28,10 +28,10 @@ function Input({ handleSearchWord }: InputProps) {
       <InputBox
         placeholder='카드, 메뉴, 혜택을 검색해 보세요'
         value={inputValue}
-        onChange={handleChange}
+        onChange={handleChangeInput}
         onKeyDown={handleEnterKey}
       />
-      <IconSearch onClick={handleKeyPress} />
+      <IconSearch onClick={handleClickSearch} />
     </InputLayout>
   );
 }

--- a/src/pages/Home/_components/Input.tsx
+++ b/src/pages/Home/_components/Input.tsx
@@ -1,12 +1,32 @@
+import { useState } from 'react';
 import styled from 'styled-components';
 
 import IconSearch from '@/assets/svg/ic_search.svg?react';
 
-function Input() {
+interface InputProps {
+  searchWord: string;
+  handleSearchWord: (keyword: string) => void;
+}
+
+function Input({ searchWord, handleSearchWord }: InputProps) {
+  const [inputValue, setInputValue] = useState(searchWord);
+
+  const handleKeyPress = () => {
+    handleSearchWord(inputValue);
+  };
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(event.target.value);
+  };
+
   return (
     <InputLayout>
-      <InputBox placeholder='카드, 메뉴, 혜택을 검색해 보세요'></InputBox>
-      <IconSearch />
+      <InputBox
+        placeholder='카드, 메뉴, 혜택을 검색해 보세요'
+        value={inputValue}
+        onChange={handleChange}
+      ></InputBox>
+      <IconSearch onClick={handleKeyPress} />
     </InputLayout>
   );
 }

--- a/src/pages/Home/_components/Input.tsx
+++ b/src/pages/Home/_components/Input.tsx
@@ -31,7 +31,7 @@ function Input({ handleSearchWord }: InputProps) {
         onChange={handleChangeInput}
         onKeyDown={handleEnterKey}
       />
-      <IconSearch onClick={handleClickSearch} />
+      <IconSearchStyled onClick={handleClickSearch} />
     </InputLayout>
   );
 }
@@ -56,5 +56,9 @@ const InputBox = styled.input`
 
   color: ${({ theme }) => theme.COLORS.HD_GRAY_02};
   outline: none;
+`;
+
+const IconSearchStyled = styled(IconSearch)`
+  cursor: pointer;
 `;
 export default Input;


### PR DESCRIPTION
<!-- pr 제목은 이슈 제목과 동일합니다! "[feat] 대성원림" -->

## 📌 관련 이슈번호

- Closes #21

## ✅ Key Changes

1. 내용
   - get을 통해 event 목록을 받아오는 api 구현했습니다.
   - query parameter를 이용해서 이벤트 제목 검색 기능 구현했습니다.
   -   query parameter에 해당하는 keyword를 input으로 부터 값의 변경을 받아서 eventBox에서 옵셔널하게 넘겨주는 방식으로 수정하였습니다.
   - 검색 아이콘을 클릭했을 때와 엔터키를 눌렀을 때 모두 검색이 가능하도록 구현하였습니다.
   - useRef를 이용하여 검색시 이벤트카드가 보이는 쪽으로 스크롤이벤트 추가하였습니다.

## 📢 To Reviewers

- event를 받아오는 api를 homeAxios에 위치하게 하였는데 event의 경우 혜택에서도 사용하니 밖으로 빼야할까요?

## 📸 스크린샷

<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
-  get을 통해 event 목록을 받아온 페이지 (홈페이지)
<img width="971" alt="image" src="https://github.com/NOW-SOPT-CDSP-WEB3/client/assets/52481403/66e218f3-8066-42ce-bb98-5939c4730134">
-  get을 통해 event 목록을 받아온 페이지 (혜택 페이지)
<img width="996" alt="image" src="https://github.com/NOW-SOPT-CDSP-WEB3/client/assets/52481403/e41eda58-44a8-47a3-b850-8a8086adfa19">

- event 검색 시 스크롤 이벤트

https://github.com/NOW-SOPT-CDSP-WEB3/client/assets/52481403/e888ebf0-5faf-4ca3-a7cf-89715a72f21c



## Reference

<!— 참고한 사이트가 있다면 링크를 공유해주세요. —>
