### PR TITLE
[feat] event api 리액트 쿼리 적용

### DIFF
--- a/src/api/axios/Home/homeAxios.ts
+++ b/src/api/axios/Home/homeAxios.ts
@@ -1,3 +1,4 @@
+import { useQuery } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 
 import instance from '@/api/axios/instance';
@@ -30,4 +31,13 @@ export const getEventsData = async (searchContent = ''): Promise<EventData[]> =>
     if (isAxiosError(error)) throw error;
     else throw new Error(MESSAGES.UNKNOWN_ERROR);
   }
+};
+
+export const useGetEvents = (searchWord?: string) => {
+  const { data, error, isError } = useQuery<EventData[], Error>({
+    queryKey: ['events', searchWord],
+    queryFn: () => getEventsData(searchWord || ''),
+  });
+
+  return { data, error, isError };
 };

--- a/src/api/axios/Home/homeAxios.ts
+++ b/src/api/axios/Home/homeAxios.ts
@@ -1,6 +1,6 @@
-import { useQuery } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 
+import { EventData } from '@/api/axios/Home/HomeInterface';
 import instance from '@/api/axios/instance';
 
 const AUTH_URL = {
@@ -10,14 +10,6 @@ const AUTH_URL = {
 const MESSAGES = {
   UNKNOWN_ERROR: '알수없는 오류가 발생했습니다. 다시 시도해주세요.',
 };
-
-interface EventData {
-  id: number;
-  image: string;
-  name: string;
-  description: string;
-  period: string;
-}
 
 export const getEventsData = async (searchContent = ''): Promise<EventData[]> => {
   try {
@@ -31,13 +23,4 @@ export const getEventsData = async (searchContent = ''): Promise<EventData[]> =>
     if (isAxiosError(error)) throw error;
     else throw new Error(MESSAGES.UNKNOWN_ERROR);
   }
-};
-
-export const useGetEvents = (searchWord?: string) => {
-  const { data, error, isError } = useQuery<EventData[], Error>({
-    queryKey: ['events', searchWord],
-    queryFn: () => getEventsData(searchWord || ''),
-  });
-
-  return { data, error, isError };
 };

--- a/src/api/axios/Home/homeAxios.ts
+++ b/src/api/axios/Home/homeAxios.ts
@@ -1,6 +1,6 @@
 import { isAxiosError } from 'axios';
 
-import { EventData } from '@/api/axios/Home/HomeInterface';
+import { EventData } from '@/api/axios/Home/homeInterface';
 import instance from '@/api/axios/instance';
 
 const AUTH_URL = {

--- a/src/api/axios/Home/homeInterface.ts
+++ b/src/api/axios/Home/homeInterface.ts
@@ -1,0 +1,7 @@
+export interface EventData {
+  id: number;
+  image: string;
+  name: string;
+  description: string;
+  period: string;
+}

--- a/src/api/axios/Home/homeQuery.ts
+++ b/src/api/axios/Home/homeQuery.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { EventData } from '@/api/axios/Home/HomeInterface';
 import { getEventsData } from '@/api/axios/Home/homeAxios';
+import { EventData } from '@/api/axios/Home/homeInterface';
 
 export const useGetEvents = (searchWord?: string) => {
   const { data, error, isError } = useQuery<EventData[], Error>({

--- a/src/api/axios/Home/homeQuery.ts
+++ b/src/api/axios/Home/homeQuery.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { EventData } from '@/api/axios/Home/HomeInterface';
+import { getEventsData } from '@/api/axios/Home/homeAxios';
+
+export const useGetEvents = (searchWord?: string) => {
+  const { data, error, isError } = useQuery<EventData[], Error>({
+    queryKey: ['events', searchWord],
+    queryFn: () => getEventsData(searchWord || ''),
+  });
+
+  return { data, error, isError };
+};

--- a/src/components/event/EventBox.tsx
+++ b/src/components/event/EventBox.tsx
@@ -1,42 +1,24 @@
-import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import Event from '@/components/event/Event';
 
-import { getEventsData } from '@/api/axios/Home/homeAxios';
+import { useGetEvents } from '@/api/axios/Home/homeAxios';
 
 interface EventBoxProps {
   isShowPeriod: boolean;
   searchWord?: string;
 }
 
-interface EventData {
-  id: number;
-  image: string;
-  name: string;
-  description: string;
-  period: string;
-}
-
 function EventBox({ isShowPeriod, searchWord }: EventBoxProps) {
-  const [eventData, setEventData] = useState<EventData[]>([]);
+  const { data: eventData, error, isError } = useGetEvents(searchWord);
 
-  useEffect(() => {
-    const fetchEventData = async () => {
-      try {
-        const eventData = await getEventsData(searchWord);
-        setEventData(eventData);
-      } catch (error) {
-        console.error(error);
-      }
-    };
-
-    fetchEventData();
-  }, [searchWord]);
+  if (isError) {
+    console.error(error);
+  }
 
   return (
     <EventBoxLayout>
-      {eventData.map(({ id, image, name, description, period }) => (
+      {eventData?.map(({ id, image, name, description, period }) => (
         <Event
           key={id}
           image={image}

--- a/src/components/event/EventBox.tsx
+++ b/src/components/event/EventBox.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 import Event from '@/components/event/Event';
 
-import { useGetEvents } from '@/api/axios/Home/homeAxios';
+import { useGetEvents } from '@/api/axios/Home/homeQuery';
 
 interface EventBoxProps {
   isShowPeriod: boolean;


### PR DESCRIPTION
<!-- pr 제목은 이슈 제목과 동일합니다! "[feat] 대성원림" -->

## 📌 관련 이슈번호

- Closes #35 

## ✅ Key Changes

1. 내용
   -  기존의event api 리액트 쿼리 적용해보았습니다.
```
 // 기존의 코드
 //events.tsx
 
 const [eventData, setEventData] = useState<EventData[]>([]);

  useEffect(() => {
    const fetchEventData = async () => {
      try {
        const eventData = await getEventsData(searchWord);
        setEventData(eventData);
      } catch (error) {
        console.error(error);
      }
    };

    fetchEventData();
  }, [searchWord]);
```

```
//리액트 쿼리를 적용한 후
//events.tsx

const { data: eventData, error, isError } = useGetEvents(searchWord);

 if (isError) {
    console.error(error);
  }
```
- 일단 로직이 너무 깔끔해져서 좋았고 성능적으로는 캐시 기능이 굉장히 좋다고 생각합니다! 
## 📢 To Reviewers

- 리액트 공식 문서에서 데이터를 fetch 해올 때 useEffect 를 사용하는 방식을 권장하지 않는다고 합니다.
이때까지 굉장히 많이 useEffect를 이용해서 데이터를 패칭했는데 앞으로는 리액트 쿼리르 더 많이 공부해보고 사용해보고 싶습니다.

## 📸 스크린샷

<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## Reference

<!— 참고한 사이트가 있다면 링크를 공유해주세요. —>
