### PR TITLE
Feat/#39/culture api에서 react query 적용

### DIFF
--- a/src/pages/Culture/Culture.tsx
+++ b/src/pages/Culture/Culture.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import styled from 'styled-components';
 
 import AppDownIcon from '@/assets/svg/culture_app_box_download_ic_next.svg?react';
@@ -17,31 +17,24 @@ interface CultureInfo {
   period: string;
 }
 
-interface Category {
-  name: string;
-  cultures: CultureInfo[];
-}
-
 function Culture() {
-  const [categories, setCategories] = useState<Category[]>([]);
-
-  const fetchData = async () => {
-    try {
-      const data = await getCultureData();
-
-      setCategories(data.data.categories);
-    } catch {
-      console.error(Error);
-    }
-  };
-
-  useEffect(() => {
-    fetchData();
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['culturePageData'],
+    queryFn: getCultureData,
   });
+
+  if (isLoading) {
+    return <div>isLoading</div>;
+  }
+  if (isError) {
+    return <div>error</div>;
+  }
+
+  const categories = data.data.categories;
 
   return (
     <CultureLayout>
-      {categories?.map((category) => (
+      {categories?.map((category: { name: string; cultures: CultureInfo[] }) => (
         <CardListBox key={category.name}>
           <Name>{category.name}</Name>
           <InfoBox>

--- a/src/pages/Culture/Culture.tsx
+++ b/src/pages/Culture/Culture.tsx
@@ -24,19 +24,20 @@ interface Category {
 
 function Culture() {
   const [categories, setCategories] = useState<Category[]>([]);
-  try {
-    const fetchData = async () => {
+
+  const fetchData = async () => {
+    try {
       const data = await getCultureData();
 
       setCategories(data.data.categories);
-    };
+    } catch {
+      console.error(Error);
+    }
+  };
 
-    useEffect(() => {
-      fetchData();
-    });
-  } catch {
-    console.error(Error);
-  }
+  useEffect(() => {
+    fetchData();
+  });
 
   return (
     <CultureLayout>


### PR DESCRIPTION
<!-- pr 제목은 이슈 제목과 동일합니다! "[feat] 대성원림" -->

## 📌 관련 이슈번호

- Closes #39 

## ✅ Key Changes

1. 내용
   - 기존코드
```
function Culture() {
  const [categories, setCategories] = useState<Category[]>([]);
  try {
    const fetchData = async () => {
      const data = await getCultureData();

      setCategories(data.data.categories);
    };

    useEffect(() => {
      fetchData();
    });
  } catch {
    console.error(Error);
```


에서 react query 사용결과 

```
function Culture() {
  const { data, isLoading, isError } = useQuery({
    queryKey: ['culturePageData'],
    queryFn: getCultureData,
  });

  if (isLoading) {
    return <div>isLoading</div>;
  }
  if (isError) {
    return <div>error</div>;
  }

  const categories = data.data.categories;
```

다음과 같이 수정되었습니다!

리액트 쿼리를 사용하는 이유로, 서버 관련 상태를 따로 관리하지 않아도 된다/ 실시간 서버 통신을 통한 데이터 갱신이 가능하다/ 캐싱 기능이 있어 불필요한 서버 요청을 줄일 수 있다.등이 있다고 공부했지만, 아직 잘 이해되지는 않고 와닿는 부분은
 - get 할때 useEffect를 사용하지 않아도 된다?!
- 상태 선언을 하나도 안해도 되는군!
- 오 좋은 것이군!
이정도 인 것 같습니다..! 이해되도록 추가적으로 공부해보겠습니다..! 감사합니다
## 📢 To Reviewers

-

## 📸 스크린샷

<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
<img width="1470" alt="컴포넌트 확대" src="https://github.com/NOW-SOPT-CDSP-WEB3/client/assets/157878428/84a3df19-028e-4d20-88cd-0bed67471781">
<img width="581" alt="space" src="https://github.com/NOW-SOPT-CDSP-WEB3/client/assets/157878428/8ee81192-5ebc-4f9c-af9d-15412fb86953">
<img width="826" alt="culture~하단" src="https://github.com/NOW-SOPT-CDSP-WEB3/client/assets/157878428/c3ee2a15-a702-40d7-a46f-eb97df1c4344">



## Reference

<!— 참고한 사이트가 있다면 링크를 공유해주세요. —>


https://velog.io/@minseok_yun/React-useState-useEffect-useQuery-%EB%A1%9C-%EB%8C%80%EC%B2%B4%ED%95%98%EA%B8%B0
