### PR TITLE
로그인 API에서 리액트 쿼리 활용

### DIFF
--- a/src/api/axios/Auth/authAxios.ts
+++ b/src/api/axios/Auth/authAxios.ts
@@ -1,30 +1,11 @@
-import { isAxiosError } from 'axios';
-
+import { IloginData } from '@/api/axios/Auth/authInterfaces';
 import instance from '@/api/axios/instance';
 
 const AUTH_URL = {
   LOGIN: '/api/auth/login',
 };
 
-const MESSAGES = {
-  LOGIN: {
-    SUCCESS: '로그인에 성공하였습니다.',
-    ERROR: '로그인에 실패했습니다. 아이디 또는 비밀번호를 확인해주세요.',
-  },
-  UNKNOWN_ERROR: '알수없는 오류가 발생했습니다. 다시 시도해주세요.',
-};
-
-interface IloginData {
-  email: string;
-  password: string;
-}
-
 export const userLogin = async (loginData: IloginData) => {
-  try {
-    await instance.post(AUTH_URL.LOGIN, loginData);
-    alert(MESSAGES.LOGIN.SUCCESS);
-  } catch (e) {
-    if (isAxiosError(e)) alert(MESSAGES.LOGIN.ERROR);
-    else alert(MESSAGES.UNKNOWN_ERROR);
-  }
+  const { data } = await instance.post(AUTH_URL.LOGIN, loginData);
+  return data;
 };

--- a/src/api/axios/Auth/authInterfaces.ts
+++ b/src/api/axios/Auth/authInterfaces.ts
@@ -1,0 +1,4 @@
+export interface IloginData {
+  email: string;
+  password: string;
+}

--- a/src/api/axios/Auth/authInterfaces.ts
+++ b/src/api/axios/Auth/authInterfaces.ts
@@ -2,3 +2,7 @@ export interface IloginData {
   email: string;
   password: string;
 }
+
+export interface ILoginResponse {
+  data: { userId: number };
+}

--- a/src/api/axios/Auth/authQuery.ts
+++ b/src/api/axios/Auth/authQuery.ts
@@ -5,7 +5,7 @@ import { useAtom } from 'jotai';
 import { memberIdAtom } from '@/store/globalStore';
 
 import { userLogin } from '@/api/axios/Auth/authAxios';
-import { IloginData } from '@/api/axios/Auth/authInterfaces';
+import { ILoginResponse, IloginData } from '@/api/axios/Auth/authInterfaces';
 
 const MESSAGES = {
   LOGIN: {
@@ -14,9 +14,6 @@ const MESSAGES = {
   },
   UNKNOWN_ERROR: '알수없는 오류가 발생했습니다. 다시 시도해주세요.',
 };
-interface ILoginResponse {
-  data: { userId: number };
-}
 
 export const useUserLogin = () => {
   const [, setMemberId] = useAtom(memberIdAtom);

--- a/src/api/axios/Auth/authQuery.ts
+++ b/src/api/axios/Auth/authQuery.ts
@@ -1,0 +1,49 @@
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError, isAxiosError } from 'axios';
+import { useAtom } from 'jotai';
+
+import { memberIdAtom } from '@/store/globalStore';
+
+import { userLogin } from '@/api/axios/Auth/authAxios';
+import { IloginData } from '@/api/axios/Auth/authInterfaces';
+
+const MESSAGES = {
+  LOGIN: {
+    SUCCESS: '로그인에 성공하였습니다.',
+    ERROR: '로그인에 실패했습니다. 아이디 또는 비밀번호를 확인해주세요.',
+  },
+  UNKNOWN_ERROR: '알수없는 오류가 발생했습니다. 다시 시도해주세요.',
+};
+interface ILoginResponse {
+  memberId: number;
+}
+
+// export const useUserLogin = () => {
+//   return useMutation({
+//     mutationFn: userLogin,
+//     onSuccess: (data) => {
+//       const { setMemberId } = useAtom(memberIdAtom);
+//       setMemberId(data.memberId);
+//       alert(MESSAGES.LOGIN.SUCCESS);
+//     },
+
+//   });
+// };
+
+export const useUserLogin = () => {
+  const [, setMemberId] = useAtom(memberIdAtom);
+
+  const mutation = useMutation<ILoginResponse, AxiosError, IloginData>({
+    mutationFn: userLogin,
+    onSuccess: (data) => {
+      setMemberId(data.memberId);
+      alert(MESSAGES.LOGIN.SUCCESS);
+    },
+    onError: (e) => {
+      if (isAxiosError(e)) alert(MESSAGES.LOGIN.ERROR);
+      else alert(MESSAGES.UNKNOWN_ERROR);
+    },
+  });
+
+  return mutation;
+};

--- a/src/api/axios/Auth/authQuery.ts
+++ b/src/api/axios/Auth/authQuery.ts
@@ -15,20 +15,8 @@ const MESSAGES = {
   UNKNOWN_ERROR: '알수없는 오류가 발생했습니다. 다시 시도해주세요.',
 };
 interface ILoginResponse {
-  memberId: number;
+  data: { userId: number };
 }
-
-// export const useUserLogin = () => {
-//   return useMutation({
-//     mutationFn: userLogin,
-//     onSuccess: (data) => {
-//       const { setMemberId } = useAtom(memberIdAtom);
-//       setMemberId(data.memberId);
-//       alert(MESSAGES.LOGIN.SUCCESS);
-//     },
-
-//   });
-// };
 
 export const useUserLogin = () => {
   const [, setMemberId] = useAtom(memberIdAtom);
@@ -36,7 +24,8 @@ export const useUserLogin = () => {
   const mutation = useMutation<ILoginResponse, AxiosError, IloginData>({
     mutationFn: userLogin,
     onSuccess: (data) => {
-      setMemberId(data.memberId);
+      const { userId } = data.data;
+      setMemberId(userId);
       alert(MESSAGES.LOGIN.SUCCESS);
     },
     onError: (e) => {

--- a/src/layout/_components/LayoutAuthButtons.tsx
+++ b/src/layout/_components/LayoutAuthButtons.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { userLogin } from '@/api/axios/Auth/authAxios';
+import { useUserLogin } from '@/api/axios/Auth/authQuery';
 
 // 회원가입 UI가 없어서, 로그인 아이디는 하나로 고정
 const loginData = {
@@ -9,6 +9,8 @@ const loginData = {
 };
 
 function LayoutAuthButtons() {
+  const { mutate: userLogin } = useUserLogin();
+
   const handleLoginClick = () => {
     userLogin(loginData);
   };


### PR DESCRIPTION
<!-- pr 제목은 이슈 제목과 동일합니다! "[feat] 대성원림" -->

## 📌 관련 이슈번호

- Closes #31 

## ✅ Key Changes

1. useMutation을 적용하고 커스텀 훅으로 따로 분리하여 로그인을 구현하였습니다. 구웃
- error, isError 객체를 받아서 처리하는 대신, onError로 에러처리를 하고, onSuccess를 통해 성공했을 떄의 로직을 구현하였습니다
 ```
//authQuery.ts
export const useUserLogin = () => {
  const [, setMemberId] = useAtom(memberIdAtom);

  const mutation = useMutation<ILoginResponse, AxiosError, IloginData>({
    mutationFn: userLogin,
    onSuccess: (data) => {
      const { userId } = data.data;
      setMemberId(userId);
      alert(MESSAGES.LOGIN.SUCCESS);
    },
    onError: (e) => {
      if (isAxiosError(e)) alert(MESSAGES.LOGIN.ERROR);
      else alert(MESSAGES.UNKNOWN_ERROR);
    },
  });

  return mutation;
};

```

```
//AuthLoginButtons.tsx
function LayoutAuthButtons() {
  const { mutate: userLogin } = useUserLogin();

  const handleLoginClick = () => {
    userLogin(loginData);
  };

  return (
    <LoginBox>
      <SignUpButton>회원가입</SignUpButton>
      <LoginButton onClick={handleLoginClick}>로그인</LoginButton>
    </LoginBox>
  );
}

export default LayoutAuthButtons;
```
이번 로그인 api는 제대로 구현된 것이 아니라서 큰 장점은 못느꼈지만, 추후에 react-query를 사용하기 위한 준비 단계라고 생각했습니다 구웃

## 📢 To Reviewers

-

## 📸 스크린샷

<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## Reference

<!— 참고한 사이트가 있다면 링크를 공유해주세요. —>
